### PR TITLE
Not exiting cef-bootstrap and obs32

### DIFF
--- a/obs-browser/main-source.cpp
+++ b/obs-browser/main-source.cpp
@@ -117,7 +117,8 @@ static void *browser_source_create(obs_data_t *settings, obs_source_t *source)
 static void browser_source_destroy(void *data)
 {
 	BrowserSource *bs = static_cast<BrowserSource *>(data);
-
+	
+	bs = NULL;
 	delete bs;
 }
 

--- a/obs-browser/main-source.cpp
+++ b/obs-browser/main-source.cpp
@@ -118,8 +118,8 @@ static void browser_source_destroy(void *data)
 {
 	BrowserSource *bs = static_cast<BrowserSource *>(data);
 	
-	bs = NULL;
 	delete bs;
+	bs = NULL;
 }
 
 


### PR DESCRIPTION
On windows, whenever OBS was closed, a cef-bootstrap.exe process and the obs32.exe process kept running.
Setting the bs pointer to NULL after delete fixed this issue.