### PR TITLE
Set bs pointer to NULL before deleting

### DIFF
--- a/obs-browser/main-source.cpp
+++ b/obs-browser/main-source.cpp
@@ -118,6 +118,7 @@ static void browser_source_destroy(void *data)
 {
 	BrowserSource *bs = static_cast<BrowserSource *>(data);
 
+	bs = NULL;
 	delete bs;
 }
 


### PR DESCRIPTION
On windows, whenever OBS was closed, a cef-bootstrap.exe process and the obs32.exe process kept running.
Setting the bs pointer to NULL before delete seemed to fix this issue.