### PR TITLE
Update OS X build to support newer CEF and new features added to windows version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ target_include_directories(obs-browser PRIVATE
 
 if (APPLE)
 	target_include_directories(obs-browser PUBLIC 
-		"shared-apple")
+		"shared-apple" ${CEF_INCLUDE_DIR})
 else(APPLE)
 	target_include_directories_system(obs-browser PUBLIC ${CEF_INCLUDE_DIR})
 endif(APPLE)
@@ -147,7 +147,8 @@ else(NOT APPLE)
 	list(APPEND obs-browser_LIBRARIES 
 		${COCOA_FRAMEWORK} 
 		${APPKIT_FRAMEWORK}
-		${IOSURFACE_FRAMEWORK})
+		${IOSURFACE_FRAMEWORK}
+		${CEF_LIBRARIES})
 endif(NOT APPLE)
 
 target_link_libraries(obs-browser 
@@ -255,6 +256,9 @@ if (APPLE)
 		MACOSX_BUNDLE_BUNDLE_NAME "CEF Helper"
 		MACOSX_BUNDLE_GUI_IDENTIFIER "org.catchexception.cef.cef-bootstrap")
 
+
+	add_custom_command(TARGET obs-browser POST_BUILD
+		COMMAND install_name_tool -change "@executable_path/Chromium Embedded Framework" "@rpath/CEF.app/Contents/Frameworks/Chromium Embedded Framework.framework/Chromium Embedded Framework" "$<TARGET_FILE:obs-browser>")
 
 	add_custom_command(TARGET cef-isolation
 		# Disable taskbar visibility

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,9 +109,6 @@ endif(APPLE)
 
 set(obs-browser_LIBRARIES
 	libobs)
-	
-set(libobs_LIBRARIES
-	libobs)
 
 if (APPLE)
 	list(APPEND obs-browser_LIBRARIES
@@ -212,7 +209,6 @@ if(APPLE)
 		${CEF_LIBRARIES}
 		${APPKIT_FRAMEWORK}
 		${IOSURFACE_FRAMEWORK}
-		${libobs_LIBRARIES}
 		)
 
 endif(APPLE)
@@ -285,15 +281,13 @@ if (APPLE)
 
 	add_custom_command(TARGET cef-isolation POST_BUILD
 		# Remember if you change this but don't cause a recompile in the shared object it will not rename it successfully
-		COMMAND install_name_tool -change "@executable_path/Chromium Embedded Framework" "@rpath/Chromium Embedded Framework.framework/Chromium Embedded Framework" "$<TARGET_FILE:cef-isolation>"
-		COMMAND install_name_tool -change "@rpath/libobs.0.dylib" "@executable_path/../Frameworks/libobs.0.dylib" "$<TARGET_FILE:cef-isolation>"		
+		COMMAND install_name_tool -change "@executable_path/Chromium Embedded Framework" "@rpath/Chromium Embedded Framework.framework/Chromium Embedded Framework" "$<TARGET_FILE:cef-isolation>"		
 
 		# Make a Frameworks directory
 		COMMAND mkdir -p "$<TARGET_FILE_DIR:cef-isolation>/../Frameworks"
 
 		# Copy the CEF and support frameworks
 		COMMAND cp -Rf "${CEF_ROOT_DIR}/Release/Chromium Embedded Framework.framework" "$<TARGET_FILE_DIR:cef-isolation>/../Frameworks/"
-		COMMAND cp -Rf "$<TARGET_FILE_DIR:cef-isolation>/../../../../../libobs/libobs.0.dylib" "$<TARGET_FILE_DIR:cef-isolation>/../Frameworks/"
 
 		# Setup the helper apps
 		COMMAND rm -rf "$<TARGET_FILE_DIR:cef-isolation>/../Frameworks/CEF Helper.app"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,9 @@ endif(APPLE)
 
 set(obs-browser_LIBRARIES
 	libobs)
+	
+set(libobs_LIBRARIES
+	libobs)
 
 if (APPLE)
 	list(APPEND obs-browser_LIBRARIES
@@ -165,7 +168,9 @@ if(APPLE)
 		shared/browser-client.cpp
 		shared/browser-task.cpp
 		shared/browser-app.cpp
-		shared/browser-scheme.cpp)
+		shared/browser-scheme.cpp
+		shared/base64.cpp
+		obs-browser/browser-load-handler.cpp)
 
 	set(cef-isolation_HEADERS
 		shared-apple/cef-logging.h
@@ -179,6 +184,8 @@ if(APPLE)
 		shared/browser-client.hpp
 		shared/browser-task.hpp
 		shared/browser-app.hpp
+		shared/base64.hpp
+		obs-browser/browser-load-handler.hpp
 		shared/browser-scheme.hpp
 		shared/browser-types.h
 		shared-apple/browser-bridges.h)
@@ -204,7 +211,9 @@ if(APPLE)
 	target_link_libraries(cef-isolation
 		${CEF_LIBRARIES}
 		${APPKIT_FRAMEWORK}
-		${IOSURFACE_FRAMEWORK})
+		${IOSURFACE_FRAMEWORK}
+		${libobs_LIBRARIES}
+		)
 
 endif(APPLE)
 
@@ -258,34 +267,39 @@ if (APPLE)
 
 
 	add_custom_command(TARGET obs-browser POST_BUILD
-		COMMAND install_name_tool -change "@executable_path/Chromium Embedded Framework" "@rpath/CEF.app/Contents/Frameworks/Chromium Embedded Framework.framework/Chromium Embedded Framework" "$<TARGET_FILE:obs-browser>")
+		COMMAND install_name_tool -change "@executable_path/Chromium Embedded Framework" "@rpath/CEF.app/Contents/Frameworks/Chromium Embedded Framework.framework/Chromium Embedded Framework" "$<TARGET_FILE:obs-browser>"
+		)
 
 	add_custom_command(TARGET cef-isolation
 		# Disable taskbar visibility
-		COMMAND defaults write "$<TARGET_FILE_DIR:cef-isolation>/../Info.plist" "LSUIElement" true)
+		COMMAND defaults write "$<TARGET_FILE_DIR:cef-isolation>/../Info.plist" "LSUIElement" true
+		)
 
 	add_custom_command(TARGET cef-bootstrap POST_BUILD
 		# Remember if you change this but don't cause a recompile it will not rename it successfully
 		COMMAND install_name_tool -change "@executable_path/Chromium Embedded Framework" "@rpath/Chromium Embedded Framework.framework/Chromium Embedded Framework" "$<TARGET_FILE:cef-bootstrap>"
 		
 		# Disable taskbar visibility
-		COMMAND defaults write "$<TARGET_FILE_DIR:cef-bootstrap>/../Info.plist" "LSUIElement" true)
+		COMMAND defaults write "$<TARGET_FILE_DIR:cef-bootstrap>/../Info.plist" "LSUIElement" true
+		)
 
 	add_custom_command(TARGET cef-isolation POST_BUILD
 		# Remember if you change this but don't cause a recompile in the shared object it will not rename it successfully
 		COMMAND install_name_tool -change "@executable_path/Chromium Embedded Framework" "@rpath/Chromium Embedded Framework.framework/Chromium Embedded Framework" "$<TARGET_FILE:cef-isolation>"
+		COMMAND install_name_tool -change "@rpath/libobs.0.dylib" "@executable_path/../Frameworks/libobs.0.dylib" "$<TARGET_FILE:cef-isolation>"		
 
 		# Make a Frameworks directory
 		COMMAND mkdir -p "$<TARGET_FILE_DIR:cef-isolation>/../Frameworks"
 
 		# Copy the CEF and support frameworks
 		COMMAND cp -Rf "${CEF_ROOT_DIR}/Release/Chromium Embedded Framework.framework" "$<TARGET_FILE_DIR:cef-isolation>/../Frameworks/"
+		COMMAND cp -Rf "$<TARGET_FILE_DIR:cef-isolation>/../../../../../libobs/libobs.0.dylib" "$<TARGET_FILE_DIR:cef-isolation>/../Frameworks/"
 
 		# Setup the helper apps
 		COMMAND rm -rf "$<TARGET_FILE_DIR:cef-isolation>/../Frameworks/CEF Helper.app"
 		COMMAND cp -Rf "$<TARGET_FILE_DIR:cef-bootstrap>/../../../CEF Helper.app" "$<TARGET_FILE_DIR:cef-isolation>/../Frameworks"
-		COMMAND "BUILT_PRODUCTS_DIR=$<TARGET_FILE_DIR:cef-isolation>/../../.." "CONTENTS_FOLDER_PATH=CEF.app/Contents" "${CEF_ROOT_DIR}/tools/make_more_helpers.sh" "Frameworks" "CEF")
-
+		)
+		
 endif(APPLE)
 
 if(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,10 +44,7 @@ set(obs-browser_SOURCES
 	obs-browser/main.cpp
 	obs-browser/main-source.cpp
 	shared/browser-source.cpp
-	shared/base64.cpp
-	obs-browser/browser-load-handler.cpp
-	shared/browser-scheme.cpp
-)
+	shared/base64.cpp)
 
 set(obs-browser_HEADERS
 	shared/browser-manager.hpp
@@ -56,8 +53,6 @@ set(obs-browser_HEADERS
 	shared/browser-settings.hpp
 	shared/browser-types.h
 	shared/base64.hpp
-	obs-browser/browser-load-handler.hpp
-	shared/browser-scheme.hpp
 	shared/browser-types.h)
 
 if (APPLE)
@@ -94,7 +89,9 @@ else (APPLE)
 		obs-browser/browser-source-listener-base.cpp
 		obs-browser/browser-manager-base.cpp
 		obs-browser/browser-render-handler.cpp
-		obs-browser/browser-source-base.cpp)
+		obs-browser/browser-source-base.cpp
+		obs-browser/browser-load-handler.cpp
+		shared/browser-scheme.cpp)
 
 	list(APPEND obs-browser_HEADERS
 		shared/browser-client.hpp
@@ -103,7 +100,9 @@ else (APPLE)
 		obs-browser/browser-source-listener-base.hpp
 		obs-browser/browser-manager-base.hpp
 		obs-browser/browser-render-handler.hpp
-		obs-browser/browser-source-base.hpp)
+		obs-browser/browser-source-base.hpp
+		obs-browser/browser-load-handler.hpp
+		shared/browser-scheme.hpp)
 
 endif(APPLE)
 
@@ -127,7 +126,7 @@ target_include_directories(obs-browser PRIVATE
 
 if (APPLE)
 	target_include_directories(obs-browser PUBLIC 
-		"shared-apple" ${CEF_INCLUDE_DIR})
+		"shared-apple")
 else(APPLE)
 	target_include_directories_system(obs-browser PUBLIC ${CEF_INCLUDE_DIR})
 endif(APPLE)
@@ -147,8 +146,7 @@ else(NOT APPLE)
 	list(APPEND obs-browser_LIBRARIES 
 		${COCOA_FRAMEWORK} 
 		${APPKIT_FRAMEWORK}
-		${IOSURFACE_FRAMEWORK}
-		${CEF_LIBRARIES})
+		${IOSURFACE_FRAMEWORK})
 endif(NOT APPLE)
 
 target_link_libraries(obs-browser 
@@ -208,8 +206,7 @@ if(APPLE)
 	target_link_libraries(cef-isolation
 		${CEF_LIBRARIES}
 		${APPKIT_FRAMEWORK}
-		${IOSURFACE_FRAMEWORK}
-		)
+		${IOSURFACE_FRAMEWORK})
 
 endif(APPLE)
 

--- a/cef-isolation/cef-isolated-client.mm
+++ b/cef-isolation/cef-isolated-client.mm
@@ -31,6 +31,7 @@
 
 #include "browser-handle.h"
 #include "browser-render-handler.hpp"
+#include "obs-browser/browser-load-handler.hpp"
 
 #import "cef-isolated-client.h"
 
@@ -76,9 +77,12 @@ void sync_on_cef_ui(dispatch_block_t block)
 
 		CefRefPtr<BrowserRenderHandler> browserRenderHandler =
 				new BrowserRenderHandler(browserHandle);
+				
+		CefRefPtr<BrowserLoadHandler> loadHandler =
+				new BrowserLoadHandler(std::string([browserSettings.css UTF8String]));
 
 		CefRefPtr<BrowserClient> browserClient =
-				new BrowserClient(browserRenderHandler.get(),NULL);
+				new BrowserClient(browserRenderHandler.get(),loadHandler);
 
 		CefWindowInfo windowInfo;
 		windowInfo.view = nullptr;

--- a/cef-isolation/cef-isolated-client.mm
+++ b/cef-isolation/cef-isolated-client.mm
@@ -78,7 +78,7 @@ void sync_on_cef_ui(dispatch_block_t block)
 				new BrowserRenderHandler(browserHandle);
 
 		CefRefPtr<BrowserClient> browserClient =
-				new BrowserClient(browserRenderHandler.get());
+				new BrowserClient(browserRenderHandler.get(),NULL);
 
 		CefWindowInfo windowInfo;
 		windowInfo.view = nullptr;

--- a/cef-isolation/main.mm
+++ b/cef-isolation/main.mm
@@ -86,7 +86,6 @@ int main (int argc, const char * argv[])
 		
 		settings.log_severity = LOGSEVERITY_DEFAULT;
 		settings.windowless_rendering_enabled = true;
-		settings.remote_debugging_port = 9222;
 
 		CefRefPtr<BrowserApp> app(new BrowserApp());
 

--- a/cef-isolation/main.mm
+++ b/cef-isolation/main.mm
@@ -86,6 +86,7 @@ int main (int argc, const char * argv[])
 		
 		settings.log_severity = LOGSEVERITY_DEFAULT;
 		settings.windowless_rendering_enabled = true;
+		settings.remote_debugging_port = 9222;
 
 		CefRefPtr<BrowserApp> app(new BrowserApp());
 

--- a/obs-browser/browser-load-handler.hpp
+++ b/obs-browser/browser-load-handler.hpp
@@ -21,8 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <include/cef_load_handler.h>
 
-#include <obs-module.h>
-
 class BrowserListener;
 
 class BrowserLoadHandler : public CefLoadHandler

--- a/obs-browser/browser-load-handler.hpp
+++ b/obs-browser/browser-load-handler.hpp
@@ -35,7 +35,7 @@ public:
 
 public: /* CefLoadHandler overrides */
 
-	virtual void BrowserLoadHandler::OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, int httpStatusCode) OVERRIDE;
+	virtual void OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, int httpStatusCode) OVERRIDE;
 
 private:
 	const std::string css;

--- a/shared-apple/browser-bridges.h
+++ b/shared-apple/browser-bridges.h
@@ -29,6 +29,7 @@ struct obs_key_event;
 @property (readonly)unsigned int width;
 @property (readonly)unsigned int height;
 @property (readonly)unsigned int fps;
+@property (readonly)NSString *css;
 
 + (id)fromBrowserSettings: (const BrowserSettings &)browserSettings;
 

--- a/shared-apple/browser-bridges.mm
+++ b/shared-apple/browser-bridges.mm
@@ -29,6 +29,8 @@
 		_width = browserSettings.width;
 		_height = browserSettings.height;
 		_fps = browserSettings.fps;
+		_css = [NSString stringWithUTF8String:
+				browserSettings.css.c_str()];
 	}
 	return self;
 }

--- a/shared/browser-scheme.cpp
+++ b/shared/browser-scheme.cpp
@@ -68,6 +68,11 @@ void BrowserSchemeHandler::GetResponseHeaders(CefRefPtr<CefResponse> response,
 
 	std::string fileExtension = fileName.substr(
 		fileName.find_last_of(".") + 1);
+	
+	if (fileExtension == "woff2") {
+		fileExtension = "woff";
+	}
+	
 	std::transform(fileExtension.begin(), fileExtension.end(),
 			fileExtension.begin(), ::tolower);
 

--- a/shared/browser-scheme.cpp
+++ b/shared/browser-scheme.cpp
@@ -31,10 +31,13 @@ bool BrowserSchemeHandler::ProcessRequest(CefRefPtr<CefRequest> request,
 		CefRefPtr<CefCallback> callback)
 {
 	CefURLParts parts;
-	CefString fileName;
 	CefParseURL(request->GetURL(), parts);
 
 	std::string path = CefString(&parts.path);
+
+	// Set fileName for use in GetResponseHeaders
+	fileName = path;
+
 	path = CefURIDecode(path, true, cef_uri_unescape_rule_t::UU_SPACES);
 	path = CefURIDecode(path, true, cef_uri_unescape_rule_t::UU_NORMAL);
 #ifdef WIN32


### PR DESCRIPTION
* updates the CMake file to solve linker issues and correctly assigns new header and source files to cef-isolation
* applies changes to cef-isolation to support custom css on OS X
* fix the issue caused by using woff2 fonts by setting the extension variable to woff (they use the same mime-type so shouldn't cause any issues)