### PR TITLE
Add a header to keep track of the Browser Plugin version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,8 @@ set(obs-browser_HEADERS
 	shared/browser-settings.hpp
 	shared/browser-types.h
 	shared/base64.hpp
-	shared/browser-types.h)
+	shared/browser-types.h
+	shared/browser-version.h)
 
 if (APPLE)
 	list(APPEND obs-browser_SOURCES

--- a/obs-browser/main.cpp
+++ b/obs-browser/main.cpp
@@ -17,6 +17,7 @@
 
 #include <obs-module.h>
 
+#include "browser-version.h"
 #include "browser-manager.hpp"
 
 OBS_DECLARE_MODULE()
@@ -27,6 +28,8 @@ struct obs_source_info browser_source_info;
 
 bool obs_module_load(void)
 {
+    blog(LOG_INFO, "[browser_source: 'Version: %s']", OBS_BROWSER_VERSION);
+
 	browser_source_info = create_browser_source_info();
 
 	BrowserManager::Instance()->SetModulePath(
@@ -34,6 +37,7 @@ bool obs_module_load(void)
 
 	BrowserManager::Instance()->Startup();
 	obs_register_source(&browser_source_info);
+
 	return true;
 }
 

--- a/shared/browser-version.h
+++ b/shared/browser-version.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define OBS_BROWSER_VERSION "1.24.0"


### PR DESCRIPTION
This file will need to be updated with the version changes with releases. Right now it logs the version to the OBS log when the plugin is loaded for easier user support. Eventually it may be exposed in places like JS callbacks in the browser.