### PR TITLE
Use boost locale when loading paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ include(BSUtils)
 find_package(LibObs REQUIRED)
 find_package(CEF REQUIRED)
 
+if (WIN32)
+	find_package(Boost REQUIRED COMPONENTS locale)
+endif(WIN32)
+
+
 if(MSVC)
 	option(USE_STATIC_CRT "Use static CRT" ON)
 
@@ -148,6 +153,10 @@ else(NOT APPLE)
 		${APPKIT_FRAMEWORK}
 		${IOSURFACE_FRAMEWORK})
 endif(NOT APPLE)
+
+if (WIN32)
+	target_include_directories(obs-browser PUBLIC ${Boost_INCLUDE_DIRS})
+endif(WIN32)
 
 target_link_libraries(obs-browser 
         ${obs-browser_LIBRARIES})

--- a/shared/browser-scheme.cpp
+++ b/shared/browser-scheme.cpp
@@ -1,10 +1,11 @@
 #include <cctype>
 #include <algorithm>
 #include <include/cef_parser.h>
+#ifdef WIN32
+#include <boost/locale/encoding_utf.hpp>
+#endif
 
 #include "browser-scheme.hpp"
-#include "obs.h"
-
 
 BrowserSchemeHandlerFactory::BrowserSchemeHandlerFactory()
 {}
@@ -34,13 +35,13 @@ bool BrowserSchemeHandler::ProcessRequest(CefRefPtr<CefRequest> request,
 	CefURLParts parts;
 	CefParseURL(request->GetURL(), parts);
 
-	std::wstring path = CefString(&parts.path);
+	std::string path = CefString(&parts.path);
 
 	path = CefURIDecode(path, true, cef_uri_unescape_rule_t::UU_SPACES);
 	path = CefURIDecode(path, true, cef_uri_unescape_rule_t::UU_URL_SPECIAL_CHARS_EXCEPT_PATH_SEPARATORS);
 #ifdef WIN32
 	//blog(LOG_INFO, "%s", path.erase(0,1));
-	inputStream.open(path.erase(0,1), std::ifstream::binary);
+	inputStream.open(boost::locale::conv::utf_to_utf<wchar_t>(path.erase(0,1)), std::ifstream::binary);
 #else
 	inputStream.open(path, std::ifstream::binary);
 #endif
@@ -69,11 +70,11 @@ void BrowserSchemeHandler::GetResponseHeaders(CefRefPtr<CefResponse> response,
 		return;
 	}
 
-	std::wstring fileExtension = fileName.substr(
-		fileName.find_last_of(L".") + 1);
+	std::string fileExtension = fileName.substr(
+		fileName.find_last_of(".") + 1);
 	
-	if (fileExtension.compare(L"woff2") == 0) {
-		fileExtension = L"woff";
+	if (fileExtension.compare("woff2") == 0) {
+		fileExtension = "woff";
 	}
 	
 	std::transform(fileExtension.begin(), fileExtension.end(),

--- a/shared/browser-scheme.hpp
+++ b/shared/browser-scheme.hpp
@@ -51,7 +51,7 @@ public:
 
 
 private:
-	std::wstring fileName;
+	std::string fileName;
 	std::ifstream inputStream;
 	bool isComplete;
 	int64 length;


### PR DESCRIPTION
http://utf8everywhere.org/

This is an alternative to PR #29 that uses Boost Locale instead of the standalone nowide library. It's a bit cleaner honestly.