### PR TITLE
Add config files for travis and appveyor.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+os: osx
+env: CMAKE_PREFIX_PATH=/usr/local/opt/qt5/lib/cmake
+
+language: cpp
+
+before_install:
+  - brew update
+  - brew install ffmpeg x264 qt5
+  - cd ../
+  - git clone  --recursive https://github.com/jp9000/obs-studio.git
+  - curl -kLO http://opensource.spotify.com/cefbuilds/cef_binary_3.2704.1434.gec3e9ed_macosx64.tar.bz2
+  - tar -xvf ./cef_binary_3.2704.1434.gec3e9ed_macosx64.tar.bz2
+  - cd ./cef_binary_3.2704.1434.gec3e9ed_macosx64
+  - mkdir build
+  - cd ./build
+  - cmake -DCMAKE_CXX_FLAGS="-std=c++11 -stdlib=libc++" -DCMAKE_EXE_LINKER_FLAGS="-std=c++11 -stdlib=libc++" ..
+  - make -j4
+  - mkdir libcef_dll
+  - mv ./libcef_dll_wrapper/libcef_dll_wrapper.a ./libcef_dll/libcef_dll_wrapper.a
+  - cd ../../
+  - mv ./obs-browser ./obs-studio/plugins/obs-browser
+  - cd ./obs-studio
+  - echo "add_subdirectory(obs-browser)" >> ./plugins/CMakeLists.txt
+
+before_script:  
+  - mkdir build
+  - cd build
+  - ls $PWD/../../cef_binary_3.2704.1434.gec3e9ed_macosx64
+  - cmake -DCEF_ROOT_DIR=$PWD/../../cef_binary_3.2704.1434.gec3e9ed_macosx64 ..
+
+script: make -j4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,38 @@
+environment:
+  FFMPEG_VERSION: 3.0.1
+  CURL_VERSION: 7.39.0
+  matrix:
+    - VSVER: Visual Studio 14 2015 Win64  
+
+platform: x64
+configuration: Debug
+
+install:
+  - git clone  --recursive https://github.com/jp9000/obs-studio.git c:\projects\obs-studio
+  - cd c:\
+  - mv c:\projects\obs-browser c:\projects\obs-studio\plugins\obs-browser
+  - echo add_subdirectory(obs-browser) > c:\projects\obs-studio\plugins\CMakeLists.txt
+  - curl -kLO http://opensource.spotify.com/cefbuilds/cef_binary_3.2704.1434.gec3e9ed_windows64.tar.bz2
+  - 7z x cef_binary_3.2704.1434.gec3e9ed_windows64.tar.bz2 -oc:\projects\cef
+  - 7z x c:\projects\cef\cef_binary_3.2704.1434.gec3e9ed_windows64.tar -oc:\projects\cef
+  - cd c:\projects\cef\cef_binary_3.2704.1434.gec3e9ed_windows64
+  - mkdir build
+  - cd ./build
+  - cmake -G "Visual Studio 14 2015 Win64" ..
+  - msbuild c:\projects\cef\cef_binary_3.2704.1434.gec3e9ed_windows64\build\cef.sln
+  - mkdir libcef_dll
+  - cp c:\projects\cef\cef_binary_3.2704.1434.gec3e9ed_windows64\build\libcef_dll_wrapper\Debug\libcef_dll_wrapper.lib c:\projects\cef\cef_binary_3.2704.1434.gec3e9ed_windows64\build\libcef_dll\libcef_dll_wrapper.lib
+
+  - cd c:\projects\obs-studio
+  - curl -kLO https://obsproject.com/downloads/dependencies2015.zip
+  - 7z x dependencies2015.zip -odependencies2015
+  - set DepsPath=%CD%\dependencies2015\win64
+  - set QTDIR=C:\Qt\5.7\msvc2015_64
+  - mkdir build
+  - cd ./build
+  - cmake -G "Visual Studio 14 2015 Win64" -DCEF_ROOT_DIR=c:\projects\cef\cef_binary_3.2704.1434.gec3e9ed_windows64 ..
+
+build:
+  project: C:\projects\obs-studio\build\obs-studio.sln
+
+


### PR DESCRIPTION
With these config files we can set up pull requests to be built on OSX and Windows to make sure that they don't break the other platform.

Eg: the OSX build will fail due to dcb39e421e89be33d0997a59cb3be816b38a717f until #29 or #31 is merged.
