### PR TITLE
Fix rare lockup on startup and missing object deallocation.

### DIFF
--- a/obs-browser/browser-manager-base.cpp
+++ b/obs-browser/browser-manager-base.cpp
@@ -112,8 +112,8 @@ BrowserManager::Impl::Impl()
 
 BrowserManager::Impl::~Impl()
 {
-	os_event_init(&dispatchEvent, OS_EVENT_TYPE_AUTO);
-	pthread_mutex_init(&dispatchLock, nullptr);
+	os_event_destroy(dispatchEvent);
+	pthread_mutex_destroy(&dispatchLock);
 }
 
 int BrowserManager::Impl::CreateBrowser(
@@ -366,6 +366,7 @@ void BrowserManager::Impl::DispatchJSEvent(const char *eventName, const char *js
 void
 BrowserManager::Impl::Startup() 
 {
+	pthread_mutex_lock(&dispatchLock);
 	int ret = pthread_create(&managerThread, nullptr,
 		browserManagerEntry, this);
 	
@@ -378,6 +379,7 @@ BrowserManager::Impl::Startup()
 	else {
 		threadAlive = true;
 	}
+	pthread_mutex_unlock(&dispatchLock);
 		
 	return;
 }


### PR DESCRIPTION
* This fixes the destructor for BrowserManager::Impl, which was leaking four objects every time it was called.
* Also fixes a startup freeze caused by the manager thread executing too early, so that threadAlive is still false:

1. pthread_create is called for the manager thread, does not yet return.
2. The manager thread immediately runs, see the 'if (!threadAlive) return;' check and terminates.
3. pthread_create returns 0 (success), threadAlive is set to true.
Source is created, but we no longer have a manager to run events.
4. Program hangs on startup.
