### PR TITLE
Use CEF multi-threaded handler and C++ify threading code.

### DIFF
--- a/obs-browser/browser-manager-base.hpp
+++ b/obs-browser/browser-manager-base.hpp
@@ -9,26 +9,22 @@
 #include <functional>
 #include <util/threading.h>
 
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <queue>
+
 #include "browser-manager.hpp"
 
-class BrowserManager::Impl
-{
+class BrowserManager::Impl {
 
 public:
 	Impl();
 	~Impl();
 
-private:
-
-	static void *browserManagerEntry(void* threadArguments);
-	void BrowserManagerEntry();
-
-
-public:
-
 	void Startup();
 	void Shutdown();
-	
+
 	int CreateBrowser(
 		const BrowserSettings &browserSettings,
 		const std::shared_ptr<BrowserListener> &browserListener);
@@ -59,24 +55,31 @@ public:
 	void ExecuteSceneChangeJSCallback(const char *name);
 
 	void RefreshPageNoCache(int browserIdentifier);
-	
+
 	void DispatchJSEvent(const char *eventName, const char *jsonString);
 
-private: 
-	void ExecuteOnBrowser(int browserIdentifier, 
-			std::function<void(CefRefPtr<CefBrowser>)> f, 
-			bool async = false);
+private:
+	void ExecuteOnBrowser(int browserIdentifier,
+		std::function<void(CefRefPtr<CefBrowser>)> f,
+		bool async = false);
 
-	void ExecuteOnAllBrowsers(std::function<void(CefRefPtr<CefBrowser>)> f, 
-			bool async = false);
+	void ExecuteOnAllBrowsers(std::function<void(CefRefPtr<CefBrowser>)> f,
+		bool async = false);
 
 private:
-	bool threadAlive;
-	os_event_t *dispatchEvent;
-	pthread_t managerThread;
-	pthread_mutex_t dispatchLock;
-
 	std::map<int, std::shared_ptr<BrowserListener>> listenerMap;
 	std::map<int, CefRefPtr<CefBrowser> > browserMap;
-	std::vector<std::function<void()>> queue;
+
+	// Holds Queue related Information
+	struct {
+		std::thread thread;
+		std::mutex mutex;
+		std::condition_variable condvar;
+		std::queue<std::function<void()>> queue;
+
+		bool bQuit = false;
+	} events;
+	static void QueueThreadMain(void*);
+	void QueueThreadLocalMain();
+
 };


### PR DESCRIPTION
This also enables CEF sandboxing, which should help users be more secure against harmful ads and sites.

I think this works because CEF tries to replace OBS's wndProc with it's own when using CefRunMessageLoop, so this should help make it not do that.