### PR TITLE
Add support for CEF version 3071

### DIFF
--- a/obs-browser/browser-manager-base.cpp
+++ b/obs-browser/browser-manager-base.cpp
@@ -1,4 +1,5 @@
 #include <util/platform.h>
+#include <include/cef_version.h>
 
 #include "browser-manager-base.hpp"
 #include "browser-task.hpp"
@@ -144,7 +145,9 @@ int BrowserManager::Impl::CreateBrowser(
 				new BrowserClient(renderHandler, loadHandler, browserOBSBridge));
 
 		CefWindowInfo windowInfo;
+#if CHROME_VERSION_BUILD < 3071
 		windowInfo.transparent_painting_enabled = true;
+#endif
 		windowInfo.width = browserSettings.width;
 		windowInfo.height = browserSettings.height;
 		windowInfo.windowless_rendering_enabled = true;

--- a/shared/browser-app.cpp
+++ b/shared/browser-app.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <string>
 #include <jansson.h>
+#include <include/cef_version.h>
 
 #include "fmt/format.h"
 #include "include/cef_browser.h"
@@ -38,7 +39,11 @@ CefRefPtr<CefRenderProcessHandler> BrowserApp::GetRenderProcessHandler()
 void BrowserApp::OnRegisterCustomSchemes(
 		CefRawPtr<CefSchemeRegistrar> registrar)
 {
+#if CHROME_VERSION_BUILD >= 3029
+	registrar->AddCustomScheme("http", true, false, false, false, true, false);
+#else
 	registrar->AddCustomScheme("http", true, false, false, false, true);
+#endif
 }
 
 void BrowserApp::OnBeforeCommandLineProcessing(


### PR DESCRIPTION
A new flag was added which specifies if defined protocols bypass Content-Security-Policy checks. This change will default that to false in order to protect users from hijacking (through ads or similar).