### PR TITLE
Disable browser panels on Wayland

### DIFF
--- a/panel/browser-panel.hpp
+++ b/panel/browser-panel.hpp
@@ -12,6 +12,10 @@
 #include <dlfcn.h>
 #endif
 
+#ifdef ENABLE_WAYLAND
+#include <obs-nix-platform.h>
+#endif
+
 struct QCefCookieManager {
 	virtual ~QCefCookieManager() {}
 
@@ -75,6 +79,14 @@ struct QCef {
 
 static inline void *get_browser_lib()
 {
+	// Disable panels on Wayland for now
+	bool isWayland = false;
+#ifdef ENABLE_WAYLAND
+	isWayland = obs_get_nix_platform() == OBS_NIX_PLATFORM_WAYLAND;
+#endif
+	if (isWayland)
+		return nullptr;
+
 	obs_module_t *browserModule = obs_get_module("obs-browser");
 
 	if (!browserModule)


### PR DESCRIPTION
### Description
Since the browser panels currently don't work on Wayland,
disable them for now, if the user is running Wayland.

### Motivation and Context
Same as https://github.com/obsproject/obs-studio/pull/4436, but this doesn't load the panels at all, instead of just removing the UI elements.

### How Has This Been Tested?
Switched between X11 and Wayland and made sure the panels were loaded on X11 and disabled on Wayland.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
