### PR TITLE
Add function to signal the browser source from JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,14 @@ Permissions required: ALL
 window.obsstudio.stopVirtualcam()
 ```
 
+#### Signal the browser source
+Permissions required: BASIC
+```js
+/**
+ * @param {string} signal - signal name
+ */
+window.obsstudio.signal(signal)
+```
 
 ### Register for visibility callbacks
 

--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -99,13 +99,26 @@ void BrowserApp::OnBeforeCommandLineProcessing(const CefString &, CefRefPtr<CefC
 #endif
 }
 
-std::vector<std::string> exposedFunctions = {"getControlLevel",     "getCurrentScene",  "getStatus",
-					     "startRecording",      "stopRecording",    "startStreaming",
-					     "stopStreaming",       "pauseRecording",   "unpauseRecording",
-					     "startReplayBuffer",   "stopReplayBuffer", "saveReplayBuffer",
-					     "startVirtualcam",     "stopVirtualcam",   "getScenes",
-					     "setCurrentScene",     "getTransitions",   "getCurrentTransition",
-					     "setCurrentTransition"};
+std::vector<std::string> exposedFunctions = {"getControlLevel",
+					     "getCurrentScene",
+					     "getStatus",
+					     "startRecording",
+					     "stopRecording",
+					     "startStreaming",
+					     "stopStreaming",
+					     "pauseRecording",
+					     "unpauseRecording",
+					     "startReplayBuffer",
+					     "stopReplayBuffer",
+					     "saveReplayBuffer",
+					     "startVirtualcam",
+					     "stopVirtualcam",
+					     "getScenes",
+					     "setCurrentScene",
+					     "getTransitions",
+					     "getCurrentTransition",
+					     "setCurrentTransition",
+					     "signal"};
 
 void BrowserApp::OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>, CefRefPtr<CefV8Context> context)
 {

--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -218,6 +218,21 @@ bool BrowserClient::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefR
 	case ControlLevel::Basic:
 		if (name == "saveReplayBuffer") {
 			obs_frontend_replay_buffer_save();
+		} else if (name == "signal") {
+			struct calldata data;
+			calldata_init(&data);
+			calldata_set_ptr(&data, "source", bs->source);
+			if (input_args->GetType(1) == VTYPE_STRING) {
+				const std::string signal = input_args->GetString(1).ToString();
+				calldata_set_string(&data, "signal", signal.c_str());
+			}
+			signal_handler_t *gsh = obs_get_signal_handler();
+			if (gsh && !obs_obj_is_private(bs->source))
+				signal_handler_signal(gsh, "source_browser_signal", &data);
+			signal_handler_t *sh = obs_source_get_signal_handler(bs->source);
+			if (sh)
+				signal_handler_signal(sh, "browser_signal", &data);
+			calldata_free(&data);
 		}
 		[[fallthrough]];
 	case ControlLevel::ReadUser:

--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -765,6 +765,7 @@ bool obs_module_load(void)
 	     cef_version_info(5), cef_version_info(6), cef_version_info(7), CEF_VERSION);
 
 	RegisterBrowserSource();
+	signal_handler_add(obs_get_signal_handler(), "void source_browser_signal(ptr source, string signal)");
 	obs_frontend_add_event_callback(handle_obs_frontend_event, nullptr);
 
 #ifdef ENABLE_BROWSER_SHARED_TEXTURE

--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -99,6 +99,9 @@ BrowserSource::BrowserSource(obs_data_t *, obs_source_t *source_) : source(sourc
 	proc_handler_add(ph, "void javascript_event(string eventName, string jsonString)", jsEventFunction,
 			 (void *)this);
 
+	signal_handler_t *sh = obs_source_get_signal_handler(source);
+	signal_handler_add(sh, "void browser_signal(ptr source, string signal)");
+
 	/* defer update */
 	obs_source_update(source, nullptr);
 


### PR DESCRIPTION
### Description
adds `void source_browser_signal(ptr source, string signal)` to the global signal handler
adds `void browser_signal(ptr source, string signal)` to the signal handler of the browser source
in javascript you can signal a signal handler like this: `window.obsstudio.signal("signal")`

### Motivation and Context
Allow JavaScript to send signals to plugins, without the need for an obs websocket connection
More generic solution replacing #423 
The use case is my Markdown Source plugin. I want to me able to size the browser source to its contents provided by the markdown. I could hack a way by forcing obs-websocket enabled and getting the obs-websocket port and password from the settings and provide that to the the browser source, but I prefer a way that I don't have to force users to enable obs-websocket.

### How Has This Been Tested?
On windows 11 with changes to the markdown source to allow it to resize it self

### Types of changes
- New feature (non-breaking change which adds functionality) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
