### PR TITLE
browser-client: Downgrade browser console log levels

### DIFF
--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -678,11 +678,11 @@ bool BrowserClient::OnConsoleMessage(CefRefPtr<CefBrowser>,
 	const char *code = "Info";
 	switch (level) {
 	case LOGSEVERITY_ERROR:
-		errorLevel = LOG_WARNING;
+		errorLevel = LOG_DEBUG;
 		code = "Error";
 		break;
 	case LOGSEVERITY_FATAL:
-		errorLevel = LOG_ERROR;
+		errorLevel = LOG_INFO;
 		code = "Fatal";
 		break;
 	default:


### PR DESCRIPTION
### Description
Downgrades browser console log messages:
- Error: LOG_WARNING -> LOG_DEBUG
- Fatal: LOG_ERROR -> LOG_INFO

### Motivation and Context
Throughout time, OBS has logged browser console.log errors as warnings in the OBS log as an easy way for browser source developers to find and fix issues with their pages. Unfortunately, this functionality seems to be almost completely ignored by many browser source providers. This logging does, however, clog up many OBS logs and result in readability issues when troubleshooting unrelated problems.

### How Has This Been Tested?
No more log spam in my OBS log from random browser pages

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
