### PR TITLE
Allow vertical scrolling of error pages

### DIFF
--- a/data/error.html
+++ b/data/error.html
@@ -122,8 +122,8 @@
 				line-height: 30px;
 				text-align: center;
 				padding: 2%;
-				width: 100vw;
-				height: 100vh;
+				max-width: 100vw;
+				min-height: 100vh;
 				box-sizing: border-box;
 				overflow: hidden;
 			}


### PR DESCRIPTION

### Description

The original copy-pasted CSS and HTML from https://obsproject.com/browser-source is intended to be centered on screen. Unintentionally, this carried over to the error display in browser docks.

This changes the `height` of `100vh` to a `min-height`, ensuring that the background still covers the full screen when the content is too small, but allows for scrolling if it overflows.

The fix alone added a horizontal scrollbar unnecessarily, so the `width` of `100vw` had to also be changed to `max-width` which fixed the unintended additional scrollbar.

### Motivation and Context

* Fixes #486 

Users should be able to see the full error and perform a page refresh without having to zoom/resize the dock.

### How Has This Been Tested?

* Open the error page (eg. by creating a dock pointing to an invalid URL) that is too small to fit all the content
* Attempt to scroll

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
