### PR TITLE
Add check for Metal in render function

### DIFF
--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -633,7 +633,14 @@ void BrowserSource::Render()
 
 	if (texture) {
 #ifdef __APPLE__
-		gs_effect_t *effect = obs_get_base_effect((hwaccel) ? OBS_EFFECT_DEFAULT_RECT : OBS_EFFECT_DEFAULT);
+		int type = gs_get_device_type();
+		gs_effect_t *effect;
+
+		if (type == GS_DEVICE_OPENGL) {
+			effect = obs_get_base_effect((hwaccel) ? OBS_EFFECT_DEFAULT_RECT : OBS_EFFECT_DEFAULT);
+		} else {
+			effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
+		}
 #else
 		gs_effect_t *effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
 #endif


### PR DESCRIPTION
### Description
Adds an explicit check for the OpenGL renderer in the current render function to set the special `rect` effect only for that renderer.

### Motivation and Context
Metal does not require the "rect" effect and can use the default effect just like D3D11.

This change does not negatively affect OBS Studio running with OpenGL as its renderer, but unlocks use of browser sources for the Metal renderer.

### How Has This Been Tested?
Tested on macOS 15.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
