### PR TITLE
Add getItemTransform function

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,45 @@ window.obsstudio.getStatus(function (status) {
 })
 ```
 
+#### Get item transform
+Permissions required: READ_OBS
+```js
+/**
+ * @typedef {Object} ItemTransform
+ * @property {Object} position - Position of the item
+ * @property {number} position.x - X coordinate
+ * @property {number} position.y - Y coordinate
+ * @property {Object} scale - Scale of the item
+ * @property {number} scale.x - X scale factor
+ * @property {number} scale.y - Y scale factor
+ * @property {number} rotation - Rotation in degrees
+ * @property {number} alignment - Alignment flags
+ * @property {number} boundsType - Bounds type (0 = None, 1 = Stretch, 2 = Scale inner, 3 = Scale outer, 4 = Scale to width, 5 = Scale to height, 6 = Scale to fit, 7 = Scale to fill)
+ * @property {number} boundsAlignment - Bounds alignment flags
+ * @property {Object} crop - Crop settings
+ * @property {number} crop.top - Top crop in pixels
+ * @property {number} crop.right - Right crop in pixels
+ * @property {number} crop.bottom - Bottom crop in pixels
+ * @property {number} crop.left - Left crop in pixels
+ * @property {number} sourceWidth - Width of the source
+ * @property {number} sourceHeight - Height of the source
+ * @property {number} sceneWidth - Width of the scene
+ * @property {number} sceneHeight - Height of the scene
+ */
+
+/**
+ * @callback ItemTransformCallback
+ * @param {ItemTransform|null} transform - The transform information for the current browser source, or null if not found
+ */
+
+/**
+ * @param {ItemTransformCallback} cb - The callback that receives the transform information for the current browser source.
+ */
+window.obsstudio.getItemTransform(function (transform) {
+    console.log(transform);
+})
+```
+
 #### Get the current scene
 Permissions required: READ_USER
 ```js

--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -99,13 +99,13 @@ void BrowserApp::OnBeforeCommandLineProcessing(const CefString &, CefRefPtr<CefC
 #endif
 }
 
-std::vector<std::string> exposedFunctions = {"getControlLevel",     "getCurrentScene",  "getStatus",
-					     "startRecording",      "stopRecording",    "startStreaming",
-					     "stopStreaming",       "pauseRecording",   "unpauseRecording",
-					     "startReplayBuffer",   "stopReplayBuffer", "saveReplayBuffer",
-					     "startVirtualcam",     "stopVirtualcam",   "getScenes",
-					     "setCurrentScene",     "getTransitions",   "getCurrentTransition",
-					     "setCurrentTransition"};
+std::vector<std::string> exposedFunctions = {"getControlLevel",      "getCurrentScene",  "getStatus",
+					     "startRecording",       "stopRecording",    "startStreaming",
+					     "stopStreaming",        "pauseRecording",   "unpauseRecording",
+					     "startReplayBuffer",    "stopReplayBuffer", "saveReplayBuffer",
+					     "startVirtualcam",      "stopVirtualcam",   "getScenes",
+					     "setCurrentScene",      "getTransitions",   "getCurrentTransition",
+					     "setCurrentTransition", "getItemTransform"};
 
 void BrowserApp::OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>, CefRefPtr<CefV8Context> context)
 {

--- a/browser-client.hpp
+++ b/browser-client.hpp
@@ -22,6 +22,7 @@
 #include <util/threading.h>
 #include "cef-headers.hpp"
 #include "obs-browser-source.hpp"
+#include <nlohmann/json.hpp>
 
 struct BrowserSource;
 
@@ -160,6 +161,11 @@ public:
 #endif
 	/* CefLoadHandler */
 	virtual void OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, int httpStatusCode) override;
+
+	/* Item Transform Helper Functions */
+	nlohmann::json GetItemTransformData();
+	obs_sceneitem_t *FindSceneItem(obs_scene_t *scene);
+	nlohmann::json BuildTransformJson(obs_sceneitem_t *scene_item, obs_source_t *current_scene);
 
 	IMPLEMENT_REFCOUNTING(BrowserClient);
 };


### PR DESCRIPTION
### Description
This new feature adds a getItemTransform function to the browser source to retrieve its own transformation information
(position, scale, rotation, alignment, bounds, crop, and dimensions) with the default basic permission READ_OBS.

### Motivation and Context

> I was really shocked to discover that this feature doesn't exist. Thinking about what information a browser should be able to read out, this would be my first thought:
> 
> 1. Missing essential information: window.outerWidth / screen.width or similar tells you the size of the browser source itself BUT not if a user messed up the aspect ratio or scaled down the source via transforming. Currently, the only way to get this information is by using the websocket. This leads to the next big issue:
> 2. HTTPS websites can't access a non-secure Websocket: When providing browser sources to streamers, they are usually all served via HTTPS— The issue? Mixed Content. **When serving the Browser Source via HTTPS, we can't access the non-secure websocket.** This means I would need to host a separate HTTP overlay just to be able to read out how my source is configured. Serving a browser source without HTTPS is no longer acceptable and will discourage users, as HTTP is widely considered insecure.
> 3. Least Privilliges: Additionally, WebSockets grant me full rights to do whatever I want—technically. So as a user, you wouldn't really want to have that enabled just to read out some basic information. This implementation is read-only and can't harm anyone but provide essential value. 

I can provide further reasons if needed, but I think the case is clear.

### How Has This Been Tested?
Environment: Windows 11 x64, OBS Studio 31.1.2 (build 104)

- I've used the buildin obs debugging tool to access the console and compare the output to the settings I've changed of the browser source and then called in the console:
```
window.obsstudio.getItemTransform(function (transform) {
    console.log(transform);
})
```
- I've tested the permission behavior handling if the user removes all permissions of the browser source -> returns null like the other functions.

For example, take a look at the screenshot and the distorted aspect ratio. With this function, I could either display an error message informing the user not to stretch the browser source, or alternatively, automatically adjust the aspect ratio internally to prevent it from breaking.

<img width="1860" height="932" alt="image" src="https://github.com/user-attachments/assets/fdfe7a0b-5aea-4f15-8606-03eac8e86ef2" />

### Types of changes
New feature (non-breaking change which adds functionality)
Documentation (a change to documentation pages)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
