### PR TITLE
add getSceneItemList, getSceneItemTransform & getBrowserInputSettings…

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,99 @@ window.obsstudio.getScenes(function (scenes) {
 })
 ```
 
+#### Get scene item list
+Permissions required: READ_USER
+```js
+/**
+ * @typedef {Object} SceneItem
+ * @property {number} id - unique scene item ID
+ * @property {string} name - name of the source
+ * @property {boolean} visible - whether the item is visible
+ * @property {boolean} locked - whether the item is locked
+ * @property {string} type - the source type
+ */
+
+/**
+ * @callback SceneItemListCallback
+ * @param {SceneItem[]} sceneItems
+ */
+
+/**
+ * @param {SceneItemListCallback} cb - The callback that receives the list of scene items in the current scene.
+ */
+window.obsstudio.getSceneItemList(function(sceneItems) {
+    console.log(sceneItems)
+})
+```
+
+#### Get scene item transform
+Permissions required: READ_USER
+```js
+/**
+ * @typedef {Object} Transform
+ * @property {Object} position - position of the item
+ * @property {number} position.x - x coordinate
+ * @property {number} position.y - y coordinate
+ * @property {number} rotation - rotation in degrees
+ * @property {Object} scale - scale of the item
+ * @property {number} scale.x - x scale factor
+ * @property {number} scale.y - y scale factor
+ * @property {number} alignment - alignment flags
+ * @property {number} boundsType - bounds type
+ * @property {number} boundsAlignment - bounds alignment
+ * @property {Object} bounds - bounds of the item
+ * @property {number} bounds.x - bounds width
+ * @property {number} bounds.y - bounds height
+ * @property {Object} crop - crop settings
+ * @property {number} crop.left - left crop
+ * @property {number} crop.top - top crop
+ * @property {number} crop.right - right crop
+ * @property {number} crop.bottom - bottom crop
+ */
+
+/**
+ * @callback TransformCallback
+ * @param {Transform} transform
+ */
+
+/**
+ * @param {TransformCallback} cb - The callback that receives the transform data.
+ * @param {string} sceneName - Name of the scene
+ * @param {number} sceneItemId - ID of the scene item
+ */
+window.obsstudio.getSceneItemTransform(function(transform) {
+    console.log(transform)
+}, "SceneName", 123)
+```
+
+#### Get browser input settings
+Permissions required: READ_USER
+```js
+/**
+ * @typedef {Object} BrowserInputSettings
+ * @property {string} inputKind - always "browser_source"
+ * @property {Object} inputSettings - browser source settings
+ * @property {number} inputSettings.height - height of the browser source
+ * @property {boolean} inputSettings.shutdown - shutdown setting
+ * @property {string} inputSettings.url - URL of the browser source
+ * @property {number} inputSettings.webpage_control_level - control level
+ * @property {number} inputSettings.width - width of the browser source
+ */
+
+/**
+ * @callback BrowserInputSettingsCallback
+ * @param {BrowserInputSettings} settings
+ */
+
+/**
+ * @param {BrowserInputSettingsCallback} cb - The callback that receives the browser input settings.
+ * @param {string} inputName - Name of the browser source
+ */
+window.obsstudio.getBrowserInputSettings(function(settings) {
+    console.log(settings)
+}, "BrowserSourceName")
+```
+
 #### Get transitions
 Permissions required: READ_USER
 ```js

--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -99,12 +99,13 @@ void BrowserApp::OnBeforeCommandLineProcessing(const CefString &, CefRefPtr<CefC
 #endif
 }
 
-std::vector<std::string> exposedFunctions = {"getControlLevel",     "getCurrentScene",  "getStatus",
-					     "startRecording",      "stopRecording",    "startStreaming",
-					     "stopStreaming",       "pauseRecording",   "unpauseRecording",
-					     "startReplayBuffer",   "stopReplayBuffer", "saveReplayBuffer",
-					     "startVirtualcam",     "stopVirtualcam",   "getScenes",
-					     "setCurrentScene",     "getTransitions",   "getCurrentTransition",
+std::vector<std::string> exposedFunctions = {"getControlLevel",       "getCurrentScene",  "getStatus",
+					     "startRecording",        "stopRecording",    "startStreaming",
+					     "stopStreaming",         "pauseRecording",   "unpauseRecording",
+					     "startReplayBuffer",     "stopReplayBuffer", "saveReplayBuffer",
+					     "startVirtualcam",       "stopVirtualcam",   "getScenes",
+					     "setCurrentScene",       "getSceneItemList", "getBrowserInputSettings",
+					     "getSceneItemTransform", "getTransitions",   "getCurrentTransition",
 					     "setCurrentTransition"};
 
 void BrowserApp::OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>, CefRefPtr<CefV8Context> context)


### PR DESCRIPTION
This is a follow up to: https://github.com/obsproject/obs-browser/pull/499 as the previous approach failed when duplicating a browser source reference.
This time I tried to stay with the implementation more closely with how the WebSocket handles it and giving developers the same flexibility.

### Description
This new feature adds:
- getSceneItemList
<img width="1152" height="312" alt="image" src="https://github.com/user-attachments/assets/6d29842c-22ba-4095-b566-5b2c8a01fbda" />

- getSceneItemTransform
<img width="742" height="641" alt="image" src="https://github.com/user-attachments/assets/65270850-eaf4-4796-8b16-2e1547d51809" />

- getBrowserInputSettings
<img width="546" height="345" alt="image" src="https://github.com/user-attachments/assets/d9663d37-f6a9-4208-b833-21b510cb4754" />



### Motivation and Context
> I was really shocked to discover that this feature doesn't exist. Thinking about what information a browser should be able to read out, this would be my first thought:
> 
> 1. Missing essential information: window.outerWidth / screen.width or similar tells you the size of the browser source itself BUT not if a user messed up the aspect ratio or scaled down the source via transforming. Currently, the only way to get this information is by using the websocket. This leads to the next big issue:
> 2. HTTPS websites can't access a non-secure Websocket: When providing browser sources to streamers, they are usually all served via HTTPS— The issue? Mixed Content. **When serving the Browser Source via HTTPS, we can't access the non-secure websocket.** This means I would need to host a separate HTTP overlay just to be able to read out how my source is configured. Serving a browser source without HTTPS is no longer acceptable and will discourage users, as HTTP is widely considered insecure.
> 3. Least Privilliges: Additionally, WebSockets grant me full rights to do whatever I want—technically. So as a user, you wouldn't really want to have that enabled just to read out some basic information. This implementation is read-only and can't harm anyone but provide essential value. 

I decided to bundle these three functions into a single PR since they are closely related:
- First, you can call getSceneItemList to retrieve all items in a scene.
- Next, use getBrowserInputSettings to identify which of those items are relevant.
- Finally, you can fetch the transformation details for each item individually using its unique ID.

### How Has This Been Tested?
Environment: Windows 11 x64, OBS Studio 31.1.2 (build 104)

- I've used the buildin obs debugging tool to access the console and compare the output to the settings I've changed of the browser source and then called in the console:
- I've tested the permission behavior handling if the user removes all permissions of the browser source -> returns null like the other functions.
- I've duplicated a browser source so I have two times the object in my sources to ensure this is working now aswell.

### Types of changes
New feature (non-breaking change which adds functionality)
Documentation (a change to documentation pages)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
