### PR TITLE
Replace implicit lamda captures for C++20

### DIFF
--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -171,7 +171,7 @@ void BrowserSource::ExecuteOnBrowser(BrowserFunc func, bool async)
 #ifdef ENABLE_BROWSER_QT_LOOP
 			QueueBrowserTask(cefBrowser, func);
 #else
-			QueueCEFTask([=]() { func(browser); });
+			QueueCEFTask([func, browser]() { func(browser); });
 #endif
 		}
 	}
@@ -257,7 +257,7 @@ void BrowserSource::SendMouseClick(const struct obs_mouse_event *event, int32_t 
 	int32_t y = event->y;
 
 	ExecuteOnBrowser(
-		[=](CefRefPtr<CefBrowser> cefBrowser) {
+		[modifiers, x, y, type, mouse_up, click_count](CefRefPtr<CefBrowser> cefBrowser) {
 			CefMouseEvent e;
 			e.modifiers = modifiers;
 			e.x = x;
@@ -275,7 +275,7 @@ void BrowserSource::SendMouseMove(const struct obs_mouse_event *event, bool mous
 	int32_t y = event->y;
 
 	ExecuteOnBrowser(
-		[=](CefRefPtr<CefBrowser> cefBrowser) {
+		[modifiers, x, y, mouse_leave](CefRefPtr<CefBrowser> cefBrowser) {
 			CefMouseEvent e;
 			e.modifiers = modifiers;
 			e.x = x;
@@ -292,7 +292,7 @@ void BrowserSource::SendMouseWheel(const struct obs_mouse_event *event, int x_de
 	int32_t y = event->y;
 
 	ExecuteOnBrowser(
-		[=](CefRefPtr<CefBrowser> cefBrowser) {
+		[modifiers, x, y, x_delta, y_delta](CefRefPtr<CefBrowser> cefBrowser) {
 			CefMouseEvent e;
 			e.modifiers = modifiers;
 			e.x = x;
@@ -304,7 +304,7 @@ void BrowserSource::SendMouseWheel(const struct obs_mouse_event *event, int x_de
 
 void BrowserSource::SendFocus(bool focus)
 {
-	ExecuteOnBrowser([=](CefRefPtr<CefBrowser> cefBrowser) { cefBrowser->GetHost()->SetFocus(focus); }, true);
+	ExecuteOnBrowser([focus](CefRefPtr<CefBrowser> cefBrowser) { cefBrowser->GetHost()->SetFocus(focus); }, true);
 }
 
 void BrowserSource::SendKeyClick(const struct obs_key_event *event, bool key_up)
@@ -326,7 +326,7 @@ void BrowserSource::SendKeyClick(const struct obs_key_event *event, bool key_up)
 #endif
 
 	ExecuteOnBrowser(
-		[=](CefRefPtr<CefBrowser> cefBrowser) {
+		[native_vkey, key_up, text, modifiers](CefRefPtr<CefBrowser> cefBrowser) {
 			CefKeyEvent e;
 			e.windows_key_code = native_vkey;
 #ifdef __APPLE__
@@ -375,7 +375,7 @@ void BrowserSource::SetShowing(bool showing)
 		}
 	} else {
 		ExecuteOnBrowser(
-			[=](CefRefPtr<CefBrowser> cefBrowser) {
+			[showing](CefRefPtr<CefBrowser> cefBrowser) {
 				CefRefPtr<CefProcessMessage> msg = CefProcessMessage::Create("Visibility");
 				CefRefPtr<CefListValue> args = msg->GetArgumentList();
 				args->SetBool(0, showing);
@@ -409,7 +409,7 @@ void BrowserSource::SetShowing(bool showing)
 void BrowserSource::SetActive(bool active)
 {
 	ExecuteOnBrowser(
-		[=](CefRefPtr<CefBrowser> cefBrowser) {
+		[active](CefRefPtr<CefBrowser> cefBrowser) {
 			CefRefPtr<CefProcessMessage> msg = CefProcessMessage::Create("Active");
 			CefRefPtr<CefListValue> args = msg->GetArgumentList();
 			args->SetBool(0, active);
@@ -512,7 +512,7 @@ void BrowserSource::Update(obs_data_t *settings)
 			width = n_width;
 			height = n_height;
 			ExecuteOnBrowser(
-				[=](CefRefPtr<CefBrowser> cefBrowser) {
+				[this](CefRefPtr<CefBrowser> cefBrowser) {
 					const CefSize cefSize(width, height);
 					cefBrowser->GetHost()->GetClient()->GetDisplayHandler()->OnAutoResize(
 						cefBrowser, cefSize);
@@ -659,7 +659,7 @@ static void ExecuteOnAllBrowsers(BrowserFunc func)
 
 void DispatchJSEvent(std::string eventName, std::string jsonString, BrowserSource *browser)
 {
-	const auto jsEvent = [=](CefRefPtr<CefBrowser> cefBrowser) {
+	const auto jsEvent = [eventName, jsonString](CefRefPtr<CefBrowser> cefBrowser) {
 		CefRefPtr<CefProcessMessage> msg = CefProcessMessage::Create("DispatchJSEvent");
 		CefRefPtr<CefListValue> args = msg->GetArgumentList();
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Implicit capture of 'this' with a capture default of '=' is deprecated in C++20. While the standard recommends replacing '=' with '=, this', that syntax is not C++17 compatible, and we will likely need some transition period where obs-studio and its modules are still built using C++17.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Want obs-studio and its submodules to build with C++20 some day.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Compiled and tested on Windows 11.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
