### PR TITLE
win32: pump messages during manager_thread join to prevent STA deadlock

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -786,7 +786,34 @@ void obs_module_unload(void)
 		if (!QueueCEFTask([]() { CefQuitMessageLoop(); }))
 			blog(LOG_DEBUG, "[obs-browser]: Failed to post CefQuit task to loop");
 
+#ifdef _WIN32
+		/* On Windows, the main thread is an STA host. Other
+		 * apartments (e.g. CEF's CrBrowserMain) may hold
+		 * cross-apartment COM proxies that need the main thread
+		 * to dispatch their Release during CoUninitialize.
+		 * A plain join() blocks without pumping messages,
+		 * causing a deadlock. Pump messages while waiting. */
+		HANDLE hThread = (HANDLE)manager_thread.native_handle();
+		while (true) {
+			DWORD res = MsgWaitForMultipleObjects(
+				1, &hThread, FALSE, INFINITE, QS_ALLINPUT);
+			if (res == WAIT_OBJECT_0)
+				break; /* thread exited */
+			if (res == WAIT_OBJECT_0 + 1) {
+				MSG msg;
+				while (PeekMessage(&msg, NULL, 0, 0,
+						   PM_REMOVE)) {
+					TranslateMessage(&msg);
+					DispatchMessage(&msg);
+				}
+			} else {
+				break; /* error */
+			}
+		}
+		manager_thread.detach(); /* already exited, avoid double-wait in dtor */
+#else
 		manager_thread.join();
+#endif
 	}
 #endif
 


### PR DESCRIPTION
Fixes #521

On Windows, `obs_module_unload` calls `manager_thread.join()` which blocks the main thread without pumping messages. During `CefShutdown()`, CEF's `CrBrowserMain` thread needs cross-apartment COM dispatch via the main thread's STA message pump. This deadlocks.

**Fix:** Replace `join()` with `MsgWaitForMultipleObjects` + message pump loop on Windows. After the thread signals, `detach()` prevents `std::thread`'s destructor from double-waiting.

**Testing:** Validated with an IAT hook PoC plugin that applies this same change at runtime:
- Before: 4/5 shutdowns hung indefinitely (60s timeout, force-killed)
- After: 14/14 shutdowns exited cleanly (~1s)

Tested on OBS 32.1.2, Windows 11.