### PR TITLE
Build with Windows file descriptors

### DIFF
--- a/cmake/os-windows.cmake
+++ b/cmake/os-windows.cmake
@@ -4,6 +4,9 @@ target_compile_definitions(obs-browser PRIVATE ENABLE_BROWSER_SHARED_TEXTURE)
 target_link_libraries(obs-browser PRIVATE CEF::Wrapper CEF::Library d3d11 dxgi)
 target_link_options(obs-browser PRIVATE /IGNORE:4099)
 
+configure_file(cmake/windows/obs-module.rc.in obs-browser.rc)
+target_sources(obs-browser PRIVATE obs-browser.rc)
+
 add_executable(obs-browser-helper WIN32 EXCLUDE_FROM_ALL)
 add_executable(OBS::browser-helper ALIAS obs-browser-helper)
 
@@ -12,6 +15,9 @@ target_sources(
   PRIVATE # cmake-format: sortable
           browser-app.cpp browser-app.hpp cef-headers.hpp obs-browser-page.manifest
           obs-browser-page/obs-browser-page-main.cpp)
+
+configure_file(cmake/windows/obs-module-helper.rc.in obs-browser-page.rc)
+target_sources(obs-browser-helper PRIVATE obs-browser-page.rc)
 
 target_include_directories(obs-browser-helper PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/deps"
                                                       "${CMAKE_CURRENT_SOURCE_DIR}/obs-browser-page")

--- a/cmake/windows/obs-module-helper.rc.in
+++ b/cmake/windows/obs-module-helper.rc.in
@@ -1,0 +1,24 @@
+1 VERSIONINFO
+FILEVERSION ${OBS_VERSION_MAJOR},${OBS_VERSION_MINOR},${OBS_VERSION_PATCH},0
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "040904B0"
+    BEGIN
+      VALUE "CompanyName", "${OBS_COMPANY_NAME}"
+      VALUE "FileDescription", "OBS Browser Page"
+      VALUE "FileVersion", "${OBS_VERSION_CANONICAL}"
+      VALUE "ProductName", "${OBS_PRODUCT_NAME}"
+      VALUE "ProductVersion", "${OBS_VERSION_CANONICAL}"
+      VALUE "Comments", "${OBS_COMMENTS}"
+      VALUE "LegalCopyright", "${OBS_LEGAL_COPYRIGHT}"
+      VALUE "InternalName", "obs-browser-page"
+      VALUE "OriginalFilename", "obs-browser-page"
+    END
+  END
+
+  BLOCK "VarFileInfo"
+  BEGIN
+    VALUE "Translation", 0x0409, 0x04B0
+  END
+END

--- a/cmake/windows/obs-module.rc.in
+++ b/cmake/windows/obs-module.rc.in
@@ -1,0 +1,24 @@
+1 VERSIONINFO
+FILEVERSION ${OBS_VERSION_MAJOR},${OBS_VERSION_MINOR},${OBS_VERSION_PATCH},0
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "040904B0"
+    BEGIN
+      VALUE "CompanyName", "${OBS_COMPANY_NAME}"
+      VALUE "FileDescription", "OBS Browser module"
+      VALUE "FileVersion", "${OBS_VERSION_CANONICAL}"
+      VALUE "ProductName", "${OBS_PRODUCT_NAME}"
+      VALUE "ProductVersion", "${OBS_VERSION_CANONICAL}"
+      VALUE "Comments", "${OBS_COMMENTS}"
+      VALUE "LegalCopyright", "${OBS_LEGAL_COPYRIGHT}"
+      VALUE "InternalName", "obs-browser"
+      VALUE "OriginalFilename", "obs-browser"
+    END
+  END
+
+  BLOCK "VarFileInfo"
+  BEGIN
+    VALUE "Translation", 0x0409, 0x04B0
+  END
+END


### PR DESCRIPTION
### Description

Ensures the `obs-browser.dll` and `obs-browser-page.exe` files have descriptors.

<img width="275" height="306" alt="image" src="https://github.com/user-attachments/assets/18152ba6-527e-40f3-bc8e-d19af2b00f0a" />

<img width="239" height="305" alt="image" src="https://github.com/user-attachments/assets/48306cb0-a8fb-4771-b800-6cefbc031da5" />


This reuses the versioning from the parent repository, rather than rewriting obs-browser's versioning to use cmake.

### Motivation and Context

Unversioned files are unhelpful, and this makes OBS Browser consistent with most other DLLs OBS ships with.

### How Has This Been Tested?

Built on Windows 10, inspected the file details.

### Types of changes

 - Tweak (non-breaking change to improve existing functionality) 

### Checklist:

- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
