### PR TITLE
Limit browser dock hang workaround to impacted Qt versions

### DIFF
--- a/panel/browser-panel-client.cpp
+++ b/panel/browser-panel-client.cpp
@@ -226,7 +226,7 @@ void QCefBrowserClient::OnBeforeClose(CefRefPtr<CefBrowser>)
 
 bool QCefBrowserClient::OnSetFocus(CefRefPtr<CefBrowser>, CefFocusHandler::FocusSource source)
 {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0) && QT_VERSION < QT_VERSION_CHECK(6, 11, 1)
 	/* Workaround for browser docks flashing/hanging at startup with Qt 6.8.x, introduced
 	 * by commit https://code.qt.io/cgit/qt/qt5.git/commit/?id=bab1fecd556ea561c4a89686293116741acfa1b4.
 	 * Refer to https://bugreports.qt.io/browse/QTBUG-136165.


### PR DESCRIPTION
### Description

This restores prior behaviour of ignoring navigation events on startup to avoid the OBS window repeatedly stealing focus once for every browser dock being restored.

* #482
### Motivation and Context

We've updated Qt. Qt have fixed the issue this code was meant to work around.

* https://github.com/obsproject/obs-studio/pull/13457
* [[QTBUG-136165] OBS Studio flashing/hanging due to changed window focus behavior - Qt Bug Tracker](https://qt-project.atlassian.net/browse/QTBUG-136165)

While working on #523 I was repeatedly impacted by this code not being run. I am thrilled to be able to re-enable it.

### How Has This Been Tested?

Launched current OBS master with CEF 127 (our current shipping version) and ensured OBS doesn't hang and also doesn't repeatedly steal focus.

### Types of changes

 - Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
