### PR TITLE
Add Property Button to Inspect Sources

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -224,6 +224,15 @@ static obs_properties_t *browser_source_get_properties(void *data)
 			return false;
 		},
 		bs);
+#if CHROME_VERSION_BUILD > 6533 || defined(__APPLE__) || defined(_WIN32)
+	obs_properties_add_button2(
+		props, "inspect", obs_module_text("Inspect"),
+		[](obs_properties_t *, obs_property_t *, void *data) {
+			static_cast<BrowserSource *>(data)->Inspect();
+			return false;
+		},
+		bs);
+#endif
 	return props;
 }
 

--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -427,6 +427,19 @@ void BrowserSource::Refresh()
 	ExecuteOnBrowser([](CefRefPtr<CefBrowser> cefBrowser) { cefBrowser->ReloadIgnoreCache(); }, true);
 }
 
+void BrowserSource::Inspect()
+{
+	ExecuteOnBrowser(
+		[](CefRefPtr<CefBrowser> cefBrowser) {
+			CefWindowInfo windowInfo;
+			windowInfo.bounds.width = 900;
+			windowInfo.bounds.height = 700;
+			CefRefPtr<CefBrowserHost> host = cefBrowser->GetHost();
+			host->ShowDevTools(windowInfo, host->GetClient(), CefBrowserSettings(), {});
+		},
+		true);
+}
+
 void BrowserSource::SetBrowser(CefRefPtr<CefBrowser> b)
 {
 	std::lock_guard<std::recursive_mutex> auto_lock(lockBrowser);

--- a/obs-browser-source.hpp
+++ b/obs-browser-source.hpp
@@ -125,6 +125,7 @@ struct BrowserSource {
 	void SetShowing(bool showing);
 	void SetActive(bool active);
 	void Refresh();
+	void Inspect();
 
 #if defined(BROWSER_EXTERNAL_BEGIN_FRAME_ENABLED) && defined(ENABLE_BROWSER_SHARED_TEXTURE)
 	inline void SignalBeginFrame();


### PR DESCRIPTION
### Description

Add an "Inspect" button to the Browser Source's Properties window to open Chrome Dev Tools.

<img width="398" height="201" alt="image" src="https://github.com/user-attachments/assets/54624f7e-5b3b-4857-86e9-d09b134f6739" />


This ensures feature parity between Browser Sources and Browser Docks (they have the same accessible via the context menu).

### Motivation and Context

Extensive research, testing, and rebuilding for #523 by pkv, Lina and myself has determined that Chromium have deprecated the old list page accessible from the Remote Debugging address, and restoring the functionality in any way will be a major maintenance burden going forward. This is due to the HTML file [they ship](https://github.com/chromium/chromium/blob/0cacfd015bc849186d70b11856f72e1b175c432b/content/shell/resources/shell_devtools_discovery_page.html#L40) containing a favicon that spans the entire link, assuming the file is shipped at all - CEF purposefully doesn't as part of Chrome Runtime.

Additionally, testing by myself and Warchamp confirms unreliable loading of `chrome://inspect` - on my machines it can take as long as 3 minutes to be able to even list pages, which is unacceptable.

Therefore, after thinking about how best to serve overlay developers in a meaningful way, rather than some kind of janky workaround using the Remote Debugging `/json/list` endpoint, ultimately I decided the best solution is the simplest one.

This also means users no longer have to launch OBS with `--remote-debugging-port=1234 --remote-allow-origins=http://localhost:1234` to be able to access Dev Tools, improving both security and usability.

### How Has This Been Tested?

On Windows 10, open the Properties window for a Browser Source, scroll down, and click Inspect.

### Types of changes

 - New feature (non-breaking change which adds functionality)

### Checklist:

- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
