### PR TITLE
Fix browser source tearing with hardware acceleration

### DIFF
--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -369,6 +369,45 @@ void BrowserClient::UpdateExtraTexture()
 	}
 }
 
+#ifdef _WIN32
+/* CEF's shared texture is pooled and only valid inside this callback;
+ * copy it into a texture we own instead of sampling it later (#488).
+ * Keyed-mutex sync was disabled "for now" in eced8c7 (2022), and since
+ * the CEF M124 rework the pooled textures have no mutex at all. */
+void BrowserClient::CopyAcceleratedTexture(void *shared_handle)
+{
+	gs_texture_t *shared = gs_texture_open_nt_shared((uint32_t)(uintptr_t)shared_handle);
+	if (!shared)
+		return;
+
+	/* No-op today (no keyed mutex); bounded wait for future producers. */
+	const bool acquired = gs_texture_acquire_sync(shared, 1, 50) == 0;
+
+	const uint32_t cx = gs_texture_get_width(shared);
+	const uint32_t cy = gs_texture_get_height(shared);
+	const gs_color_format format = gs_texture_get_color_format(shared);
+
+	/* Reallocate only on size/format change. */
+	if (!bs->texture || gs_texture_get_width(bs->texture) != cx || gs_texture_get_height(bs->texture) != cy ||
+	    gs_texture_get_color_format(bs->texture) != format) {
+		if (bs->texture)
+			gs_texture_destroy(bs->texture);
+		bs->texture = gs_texture_create(cx, cy, format, 1, nullptr, 0);
+	}
+
+	if (bs->texture)
+		gs_copy_texture(bs->texture, shared);
+
+	if (acquired)
+		gs_texture_release_sync(shared, 0);
+
+	/* Submit before CEF reuses the pooled texture. */
+	gs_flush();
+
+	gs_texture_destroy(shared);
+}
+#endif
+
 void BrowserClient::OnAcceleratedPaint(CefRefPtr<CefBrowser>, PaintElementType type, const RectList &,
 #if CHROME_VERSION_BUILD >= 6367
 				       const CefAcceleratedPaintInfo &info)
@@ -423,10 +462,15 @@ void BrowserClient::OnAcceleratedPaint(CefRefPtr<CefBrowser>, PaintElementType t
 
 	obs_enter_graphics();
 
-	if (bs->texture) {
 #ifdef _WIN32
-		//gs_texture_release_sync(bs->texture, 0);
+	/* Copy the pooled texture into our own; see CopyAcceleratedTexture(). */
+#if CHROME_VERSION_BUILD >= 6367
+	CopyAcceleratedTexture((void *)(uintptr_t)info.shared_texture_handle);
+#else
+	CopyAcceleratedTexture(shared_handle);
 #endif
+#else
+	if (bs->texture) {
 		gs_texture_destroy(bs->texture);
 		bs->texture = nullptr;
 	}
@@ -435,23 +479,13 @@ void BrowserClient::OnAcceleratedPaint(CefRefPtr<CefBrowser>, PaintElementType t
 	bs->texture = gs_texture_create_from_iosurface((IOSurfaceRef)(uintptr_t)info.shared_texture_io_surface);
 #elif defined(__APPLE__) && CHROME_VERSION_BUILD > 4183
 	bs->texture = gs_texture_create_from_iosurface((IOSurfaceRef)(uintptr_t)shared_handle);
-#elif defined(_WIN32) && CHROME_VERSION_BUILD > 4183
-	bs->texture =
-#if CHROME_VERSION_BUILD >= 6367
-		gs_texture_open_nt_shared((uint32_t)(uintptr_t)info.shared_texture_handle);
-#else
-		gs_texture_open_nt_shared((uint32_t)(uintptr_t)shared_handle);
-#endif
-	//if (bs->texture)
-	//	gs_texture_acquire_sync(bs->texture, 1, INFINITE);
-
-#elif defined(_WIN32)
-	bs->texture = gs_texture_open_shared((uint32_t)(uintptr_t)shared_handle);
 #else
 	bs->texture = gs_texture_create_from_dmabuf(info.extra.coded_size.width, info.extra.coded_size.height,
 						    format.drm_format, format.gs_format, info.plane_count, fds, strides,
 						    offsets, modifier != DRM_FORMAT_MOD_INVALID ? modifiers : NULL);
 #endif
+#endif
+
 	UpdateExtraTexture();
 	obs_leave_graphics();
 

--- a/browser-client.hpp
+++ b/browser-client.hpp
@@ -42,6 +42,9 @@ class BrowserClient : public CefClient,
 	inline bool valid() const;
 
 	void UpdateExtraTexture();
+#if defined(ENABLE_BROWSER_SHARED_TEXTURE) && defined(_WIN32)
+	void CopyAcceleratedTexture(void *shared_handle);
+#endif
 
 public:
 	BrowserSource *bs;


### PR DESCRIPTION
### Description

Since the CEF M124 OSR rework, `OnAcceleratedPaint` hands out a texture from a small internal pool, with no keyed mutex. The handle ["cannot be cached and cannot be accessed outside of this callback"](https://github.com/chromiumembedded/cef/blob/af8ada6a3ab9878669a3a6c46d9e0402279ac068/include/cef_render_handler.h#L163-L166) and the contents "should be copied to a texture owned by the client application". ["Resources will be released to the underlying pool for reuse when the callback returns"](https://github.com/chromiumembedded/cef/blob/af8ada6a3ab9878669a3a6c46d9e0402279ac068/include/internal/cef_types_win.h#L130-L131) and that the texture "is instantiated without a keyed mutex".

The current implementation does the opposite: open the handle, keep the resource as `bs->texture`, and let the render thread sample it during composition at some later point. When the compositor falls behind under CPU load, CEF is already writing a later frame into that same pooled texture while we sample it, which shows up as the one-frame swaps and tears from the issue.

#### Fix

`CopyAcceleratedTexture()` now copies the frame into a texture we own, inside the callback, while the handle is guaranteed valid. The copy target is reused across frames and only reallocated when the size or format changes. `gs_flush()` submits the copy before the callback returns, since the pooled texture can be reused after that. The render thread then samples our private, stable copy.

The `gs_texture_acquire_sync(shared, 1, 50)` is a no-op right now but it cooperates, with a bounded wait, if a future producer exposes a keyed mutex.

One note: the flush submits the copy but cannot fence it, because CEF exposes no fence through this API. This is as close to the documented contract as a consumer can get. The exposure window shrinks from a full compositor frame of sampling to command submission granularity, and the pool depth gives the copy several frame intervals of slack in practice.

### Motivation and Context
Recurrence of #488 

### How Has This Been Tested?

Retested multiple times against example from #488, and with python script to detect tear artifacts.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
