### PR TITLE
Fix premultiplied sRGB browser rendering

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -433,7 +433,7 @@ void RegisterBrowserSource()
 	info.id = "browser_source";
 	info.type = OBS_SOURCE_TYPE_INPUT;
 	info.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_AUDIO | OBS_SOURCE_CUSTOM_DRAW | OBS_SOURCE_INTERACTION |
-			    OBS_SOURCE_DO_NOT_DUPLICATE | OBS_SOURCE_SRGB;
+			    OBS_SOURCE_DO_NOT_DUPLICATE | OBS_SOURCE_SRGB | OBS_SOURCE_INITIAL_BLEND_METHOD_SRGB_OFF;
 	info.get_properties = browser_source_get_properties;
 	info.get_defaults = browser_source_get_defaults;
 	info.icon_type = OBS_ICON_TYPE_BROWSER;

--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -597,33 +597,25 @@ void BrowserSource::Render()
 		gs_effect_t *effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
 #endif
 
-		bool linear_sample = extra_texture == NULL;
 		gs_texture_t *draw_texture = texture;
-		if (!linear_sample && !obs_source_get_texcoords_centered(source)) {
+		if (extra_texture && !obs_source_get_texcoords_centered(source)) {
 			gs_copy_texture(extra_texture, texture);
 			draw_texture = extra_texture;
-
-			linear_sample = true;
 		}
 
+		const bool linear_srgb = gs_get_linear_srgb();
 		const bool previous = gs_framebuffer_srgb_enabled();
-		gs_enable_framebuffer_srgb(true);
+		gs_enable_framebuffer_srgb(linear_srgb);
 
 		gs_blend_state_push();
 		gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 
 		gs_eparam_t *const image = gs_effect_get_param_by_name(effect, "image");
 
-		const char *tech;
-		if (linear_sample) {
-			gs_effect_set_texture_srgb(image, draw_texture);
-			tech = "Draw";
-		} else {
-			gs_effect_set_texture(image, draw_texture);
-			tech = "DrawSrgbDecompress";
-		}
+		gs_effect_set_texture(image, draw_texture);
 
 		const uint32_t flip_flag = flip ? GS_FLIP_V : 0;
+		const char *tech = linear_srgb ? "DrawSrgbDecompressPremultiplied" : "Draw";
 		while (gs_effect_loop(effect, tech))
 			gs_draw_sprite(draw_texture, flip_flag, 0, 0);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Uses the scene item's linear-sRGB state to select the correct rendering path for premultiplied browser textures:

- Linear blending uses `DrawSrgbDecompressPremultiplied`.
- Nonlinear blending draws the texture without conversion.

Also sets `OBS_SOURCE_INITIAL_BLEND_METHOD_SRGB_OFF` so new browser scene items initially use nonlinear blending.

Depends on obsproject/obs-studio#13797, this fixes #469.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

This is the obs-browser companion to [obs-studio#13797](https://github.com/obsproject/obs-studio/pull/13797), which contains the core rendering changes, migration logic, and full motivation.

Chromium composites content in nonlinear sRGB, so browser sources should initially use nonlinear blending while still providing a correct linear rendering path when selected by the user.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Manually tested on a MacBook Pro with an Apple M5 Pro running macOS 26.5.2, together with the changes from obs-studio#13797.

Verified both linear and nonlinear blending with opaque and semi-transparent content over transparent, black, and white backgrounds. The test page, comparison screenshots, and detailed results are included in the main PR.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.


<!-- Complete the current GitHub AI-disclosure section truthfully. -->
- [x] I have used AI tooling in the creation of this PR.
  - AI tooling was used for research and autocomplete assistance. I deliberately reviewed, understood, and verified every submitted line of code, and personally evaluated all architectural decisions and trade-offs.
