### PR TITLE
Stabilize frames during browser resize

### DIFF
--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -319,7 +319,8 @@ void BrowserClient::OnPaint(CefRefPtr<CefBrowser>, PaintElementType type, const 
 		return;
 	}
 
-	if (bs->width != width || bs->height != height) {
+	if (bs->texture && (gs_texture_get_width(bs->texture) != static_cast<uint32_t>(width) ||
+			    gs_texture_get_height(bs->texture) != static_cast<uint32_t>(height))) {
 		obs_enter_graphics();
 		bs->DestroyTextures();
 		obs_leave_graphics();
@@ -328,8 +329,6 @@ void BrowserClient::OnPaint(CefRefPtr<CefBrowser>, PaintElementType type, const 
 	if (!bs->texture && width && height) {
 		obs_enter_graphics();
 		bs->texture = gs_texture_create(width, height, GS_BGRA, 1, (const uint8_t **)&buffer, GS_DYNAMIC);
-		bs->width = width;
-		bs->height = height;
 		obs_leave_graphics();
 	} else {
 		obs_enter_graphics();

--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -48,6 +48,7 @@ extern bool QueueCEFTask(std::function<void()> task);
 
 static mutex browser_list_mutex;
 static BrowserSource *first_browser = nullptr;
+constexpr int kResizeTextureStableFrames = 3;
 
 static void SendBrowserVisibility(CefRefPtr<CefBrowser> browser, bool isVisible)
 {
@@ -510,6 +511,10 @@ void BrowserSource::Update(obs_data_t *settings)
 			if (n_width == width && n_height == height)
 				return;
 
+			// CEF may mutate the current shared surface before publishing
+			// one with the new dimensions. Keep an immutable frame for the
+			// resize transition so it cannot render outside the source bounds.
+			CaptureResizeTexture();
 			width = n_width;
 			height = n_height;
 			ExecuteOnBrowser(
@@ -548,6 +553,40 @@ void BrowserSource::Update(obs_data_t *settings)
 	first_update = false;
 }
 
+void BrowserSource::CaptureResizeTexture()
+{
+	obs_enter_graphics();
+
+	if (resize_render) {
+		gs_texrender_destroy(resize_render);
+		resize_render = nullptr;
+	}
+	resize_match_frames = 0;
+
+	if (texture) {
+		const uint32_t textureWidth = gs_texture_get_width(texture);
+		const uint32_t textureHeight = gs_texture_get_height(texture);
+		const gs_color_space preferredSpaces[] = {GS_CS_SRGB, GS_CS_SRGB_16F, GS_CS_709_EXTENDED};
+		const gs_color_space space =
+			obs_source_get_color_space(source, OBS_COUNTOF(preferredSpaces), preferredSpaces);
+		gs_texrender_t *snapshot = gs_texrender_create(gs_get_format_from_space(space), GS_ZS_NONE);
+
+		if (snapshot && gs_texrender_begin_with_color_space(snapshot, textureWidth, textureHeight, space)) {
+			vec4 clearColor{};
+			gs_clear(GS_CLEAR_COLOR, &clearColor, 0.0f, 0);
+			gs_ortho(0.0f, static_cast<float>(textureWidth), 0.0f, static_cast<float>(textureHeight),
+				 -100.0f, 100.0f);
+			Render();
+			gs_texrender_end(snapshot);
+			resize_render = snapshot;
+		} else if (snapshot) {
+			gs_texrender_destroy(snapshot);
+		}
+	}
+
+	obs_leave_graphics();
+}
+
 void BrowserSource::Tick()
 {
 	if (os_event_try(cef_started_event) != 0)
@@ -584,27 +623,40 @@ void BrowserSource::Render()
 #endif
 
 	if (texture) {
-#ifdef __APPLE__
-		int type = gs_get_device_type();
-		gs_effect_t *effect;
-
-		if (type == GS_DEVICE_OPENGL) {
-			effect = obs_get_base_effect((hwaccel) ? OBS_EFFECT_DEFAULT_RECT : OBS_EFFECT_DEFAULT);
-		} else {
-			effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
+		const uint32_t textureWidth = gs_texture_get_width(texture);
+		const uint32_t textureHeight = gs_texture_get_height(texture);
+		const bool textureSizeMatches = textureWidth == static_cast<uint32_t>(width) &&
+						textureHeight == static_cast<uint32_t>(height);
+		gs_texture_t *resizeTexture = resize_render ? gs_texrender_get_texture(resize_render) : nullptr;
+		if (resizeTexture) {
+			resize_match_frames = textureSizeMatches ? resize_match_frames + 1 : 0;
+			// Paint surfaces can arrive out of order while CEF resizes. Only
+			// release the snapshot after the target size has remained stable.
+			if (resize_match_frames >= kResizeTextureStableFrames) {
+				gs_texrender_destroy(resize_render);
+				resize_render = nullptr;
+				resizeTexture = nullptr;
+				resize_match_frames = 0;
+			}
 		}
-#else
-		gs_effect_t *effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
-#endif
-
-		bool linear_sample = extra_texture == NULL;
-		gs_texture_t *draw_texture = texture;
-		if (!linear_sample && !obs_source_get_texcoords_centered(source)) {
+		const bool useResizeTexture = resizeTexture != nullptr;
+		bool linear_sample = useResizeTexture || extra_texture == NULL;
+		gs_texture_t *draw_texture = useResizeTexture ? resizeTexture : texture;
+		if (!useResizeTexture && !linear_sample && !obs_source_get_texcoords_centered(source)) {
 			gs_copy_texture(extra_texture, texture);
 			draw_texture = extra_texture;
 
 			linear_sample = true;
 		}
+
+#ifdef __APPLE__
+		const bool rectangleTexture = gs_get_device_type() == GS_DEVICE_OPENGL &&
+					      gs_texture_is_rect(draw_texture);
+		gs_effect_t *effect =
+			obs_get_base_effect(rectangleTexture ? OBS_EFFECT_DEFAULT_RECT : OBS_EFFECT_DEFAULT);
+#else
+		gs_effect_t *effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
+#endif
 
 		const bool previous = gs_framebuffer_srgb_enabled();
 		gs_enable_framebuffer_srgb(true);
@@ -625,7 +677,7 @@ void BrowserSource::Render()
 
 		const uint32_t flip_flag = flip ? GS_FLIP_V : 0;
 		while (gs_effect_loop(effect, tech))
-			gs_draw_sprite(draw_texture, flip_flag, 0, 0);
+			gs_draw_sprite(draw_texture, flip_flag, width, height);
 
 		gs_blend_state_pop();
 

--- a/obs-browser-source.hpp
+++ b/obs-browser-source.hpp
@@ -54,6 +54,8 @@ struct BrowserSource {
 	std::string css;
 	gs_texture_t *texture = nullptr;
 	gs_texture_t *extra_texture = nullptr;
+	gs_texrender_t *resize_render = nullptr;
+	int resize_match_frames = 0;
 	uint32_t last_cx = 0;
 	uint32_t last_cy = 0;
 	gs_color_format last_format = GS_UNKNOWN;
@@ -86,6 +88,11 @@ struct BrowserSource {
 	inline void DestroyTextures()
 	{
 		obs_enter_graphics();
+		if (resize_render) {
+			gs_texrender_destroy(resize_render);
+			resize_render = nullptr;
+			resize_match_frames = 0;
+		}
 		if (extra_texture) {
 			gs_texture_destroy(extra_texture);
 			extra_texture = nullptr;
@@ -114,6 +121,7 @@ struct BrowserSource {
 	void Destroy();
 
 	void Update(obs_data_t *settings = nullptr);
+	void CaptureResizeTexture();
 	void Tick();
 	void Render();
 


### PR DESCRIPTION
### Description

Capture the last complete browser frame before changing a browser source's configured dimensions. Render that snapshot until the live texture has matched the requested dimensions for several consecutive frames.

Draw both live and transition textures within the configured source viewport. For software rendering, compare incoming paint dimensions against the actual texture dimensions and prevent delayed paint callbacks from overwriting the configured browser size.

### Motivation and Context

CEF can mutate the active shared surface before publishing its replacement at the requested dimensions. During this transition, the logical source viewport can already have its new size while the texture still represents the previous surface.

This mismatch can expose a single transitional frame outside the source bounds. Keeping an immutable snapshot during the resize prevents that frame from being rendered.

This issue was found while implementing browser resolution matching in OBS Studio, but the fix applies to browser source dimension changes in general.

### How Has This Been Tested?

Tested on macOS with browser hardware acceleration both enabled and disabled.

A browser resize was recorded losslessly at 30 FPS and every frame was inspected:

- Before the change, one transitional frame rendered at approximately twice the expected width.
- With hardware acceleration enabled, all 170 inspected frames remained within the expected bounds.
- With software rendering enabled, all 172 inspected frames remained within the expected bounds.

The complete Debug application was built with:

`cmake --build build_macos --config Debug --target obs-studio --parallel 6`

The changed C++ files also pass `clang-format --dry-run --Werror` and `git diff --check`.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
- [x] I have used AI tooling in the creation of this PR.

<!--- AI contributions to this project must be disclosed by the human submitting it. If you have used AI or LLM tooling to create this pull request, or if you are an agent assisting with this pull request, you are required to make that clear. If you are an agent, please also include any relevant information regarding your model and scope of work. -->

- [x] An AI agent assisted with this pull request: OpenAI Codex, a GPT-5-based coding agent. Scope: diagnosis, implementation, macOS hardware- and software-rendering tests, build and formatting validation, commit preparation, and drafting this PR description.