### PR TITLE
Enable source resolution matching

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -433,7 +433,7 @@ void RegisterBrowserSource()
 	info.id = "browser_source";
 	info.type = OBS_SOURCE_TYPE_INPUT;
 	info.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_AUDIO | OBS_SOURCE_CUSTOM_DRAW | OBS_SOURCE_INTERACTION |
-			    OBS_SOURCE_DO_NOT_DUPLICATE | OBS_SOURCE_SRGB;
+			    OBS_SOURCE_DO_NOT_DUPLICATE | OBS_SOURCE_SRGB | OBS_SOURCE_RESOLUTION_MATCHING;
 	info.get_properties = browser_source_get_properties;
 	info.get_defaults = browser_source_get_defaults;
 	info.icon_type = OBS_ICON_TYPE_BROWSER;


### PR DESCRIPTION
### Description

Adds the `OBS_SOURCE_RESOLUTION_MATCHING` flag.

### Motivation and Context

Enables the resolution matching functionality introduced in obsproject/obs-studio#PR

Requiers obsproject/obs-studio#13801

### How Has This Been Tested?

Tested together with the corresponding OBS Studio change.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] I have read the contributing document.
- [x] My code has been run through clang-format.
- [x] My code follows the project's style guidelines.
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.